### PR TITLE
win, dlopen mf

### DIFF
--- a/nokhwa-bindings-windows/Cargo.toml
+++ b/nokhwa-bindings-windows/Cargo.toml
@@ -14,6 +14,8 @@ keywords = ["media-foundation", "windows", "capture", "webcam"]
 docs-only = []
 
 [dependencies]
+dlopen = "0.1"
+lazy_static = "1.4"
 
 [dependencies.nokhwa-core]
 version = "0.1"

--- a/nokhwa-bindings-windows/src/lib.rs
+++ b/nokhwa-bindings-windows/src/lib.rs
@@ -27,8 +27,11 @@
 //!
 //! No support or API stability will be given. Subject to change at any time.
 
+mod mf_wrapper;
+
 #[cfg(all(windows, not(feature = "docs-only")))]
 pub mod wmf {
+    use super::mf_wrapper::*;
     use nokhwa_core::error::NokhwaError;
     use nokhwa_core::types::{
         ApiBackend, CameraControl, CameraFormat, CameraIndex, CameraInfo, ControlValueDescription,
@@ -47,7 +50,7 @@ pub mod wmf {
     };
     use windows::Win32::Media::DirectShow::{CameraControl_Flags_Auto, CameraControl_Flags_Manual};
     use windows::Win32::Media::MediaFoundation::{
-        IMFMediaType, MFCreateSample, MF_SOURCE_READER_FIRST_VIDEO_STREAM,
+        IMFMediaType, MF_SOURCE_READER_FIRST_VIDEO_STREAM,
     };
     use windows::{
         core::{Interface, GUID, PWSTR},
@@ -64,10 +67,8 @@ pub mod wmf {
                 KernelStreaming::GUID_NULL,
                 MediaFoundation::{
                     IMFActivate, IMFAttributes, IMFMediaSource, IMFSample, IMFSourceReader,
-                    MFCreateAttributes, MFCreateMediaType, MFCreateSourceReaderFromMediaSource,
-                    MFEnumDeviceSources, MFMediaType_Video, MFShutdown, MFStartup,
-                    MFSTARTUP_NOSOCKET, MF_API_VERSION, MF_DEVSOURCE_ATTRIBUTE_FRIENDLY_NAME,
-                    MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE,
+                    MFMediaType_Video, MFSTARTUP_NOSOCKET, MF_API_VERSION,
+                    MF_DEVSOURCE_ATTRIBUTE_FRIENDLY_NAME, MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE,
                     MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_GUID,
                     MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_SYMBOLIC_LINK, MF_MT_FRAME_RATE,
                     MF_MT_FRAME_RATE_RANGE_MAX, MF_MT_FRAME_RATE_RANGE_MIN, MF_MT_FRAME_SIZE,

--- a/nokhwa-bindings-windows/src/mf_wrapper.rs
+++ b/nokhwa-bindings-windows/src/mf_wrapper.rs
@@ -1,0 +1,231 @@
+#![allow(non_snake_case)]
+
+// We use the `dlopen` crate to load the MF DLLs dynamically at runtime.
+// Because the MF DLLs are not always present on all Windows systems, we need to load them at runtime instead of linking them statically.
+// This allows us to avoid linking errors on systems that do not have the MF DLLs installed.
+
+use core::ffi::c_void;
+use dlopen::symbor::Library;
+use lazy_static;
+use windows::Win32::Media::MediaFoundation::{IMFActivate, IMFAttributes, IMFMediaSource, IMFMediaType, IMFSample, IMFSourceReader};
+use std::io::Result;
+use std::sync::{Arc, Mutex};
+use windows::core::HRESULT;
+
+type UINT32 = u32;
+type ULONG = std::os::raw::c_ulong;
+type DWORD = std::os::raw::c_ulong;
+
+const HRESULT_ERR_NO_INTERFACE: HRESULT = HRESULT(0x80004002 as u32 as i32);
+
+macro_rules! make_lib_wrapper {
+    ($s:ident,$dll:literal,$($field:ident : $tp:ty),+) => {
+        struct $s {
+            _lib: Option<Library>,
+            $($field: Option<$tp>),+
+        }
+
+        impl $s {
+            fn new() -> Self {
+                let lib_name = match get_lib_name($dll) {
+                    Ok(name) => name,
+                    Err(e) => {
+                        eprintln!("Failed to get lib name, {}", e);
+                        return Self {
+                            _lib: None,
+                            $( $field: None ),+
+                        };
+                    }
+                };
+                let lib = match Library::open(&lib_name) {
+                    Ok(lib) => Some(lib),
+                    Err(e) => {
+                        eprintln!("Failed to load library {}, {}", &lib_name, e);
+                        None
+                    }
+                };
+
+                $(let $field = if let Some(lib) = &lib {
+                    match unsafe { lib.symbol::<$tp>(stringify!($field)) } {
+                        Ok(m) => {
+                            eprintln!("method found {}", stringify!($field));
+                            Some(*m)
+                        },
+                        Err(e) => {
+                            eprintln!("Failed to load func {}, {}", stringify!($field), e);
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };)+
+
+                Self {
+                    _lib: lib,
+                    $( $field ),+
+                }
+            }
+        }
+
+        impl Default for $s {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+    }
+}
+
+fn get_lib_name(dll_name: &str) -> Result<String> {
+    let exe_file = std::env::current_exe()?;
+    if let Some(cur_dir) = exe_file.parent() {
+        let dll_name = format!("{}.dll", dll_name);
+        let full_path = cur_dir.join(dll_name);
+        if !full_path.exists() {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("{} not found", full_path.to_string_lossy().as_ref()),
+            ))
+        } else {
+            Ok(full_path.to_string_lossy().into_owned())
+        }
+    } else {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!(
+                "Invalid exe parent for {}",
+                exe_file.to_string_lossy().as_ref()
+            ),
+        ))
+    }
+}
+
+pub type FnMFEnumDeviceSources = fn(*mut c_void, *mut *mut *mut c_void, *mut UINT32) -> HRESULT;
+
+make_lib_wrapper!(
+    MFWrapper,
+    "mf",
+    MFEnumDeviceSources: FnMFEnumDeviceSources
+);
+
+pub type FnMFCreateMediaType = fn(*mut *mut c_void) -> HRESULT;
+pub type FnMFCreateAttributes = fn(*mut *mut c_void, UINT32) -> HRESULT;
+pub type FnMFStartup = fn(ULONG, DWORD) -> HRESULT;
+pub type FnMFShutdown = fn() -> HRESULT;
+pub type FnMFCreateSample = fn(*mut *mut c_void) -> HRESULT;
+
+make_lib_wrapper!(
+    MFPlatWrapper,
+    "mfplat",
+    MFCreateMediaType: FnMFCreateMediaType,
+    MFCreateAttributes: FnMFCreateAttributes,
+    MFStartup: FnMFStartup,
+    MFShutdown: FnMFShutdown,
+    MFCreateSample: FnMFCreateSample
+);
+
+pub type FnMFCreateSourceReaderFromMediaSource =
+    fn(*mut c_void, *mut c_void, *mut *mut c_void) -> HRESULT;
+make_lib_wrapper!(
+    MFReadWriteWrapper,
+    "fmreadwrite",
+    MFCreateSourceReaderFromMediaSource: FnMFCreateSourceReaderFromMediaSource
+);
+
+lazy_static::lazy_static! {
+    static ref MF_WRAPPER: Arc<Mutex<MFWrapper>> = Arc::new(Mutex::new(MFWrapper::default()));
+    static ref MF_PLAT_WRAPPER: Arc<Mutex<MFPlatWrapper>> = Arc::new(Mutex::new(MFPlatWrapper::default()));
+    static ref MF_READ_WRITE_WRAPPER: Arc<Mutex<MFReadWriteWrapper>> = Arc::new(Mutex::new(MFReadWriteWrapper::default()));
+}
+
+pub unsafe fn MFEnumDeviceSources<'a, P0>(
+    pattributes: P0,
+    pppsourceactivate: *mut *mut ::core::option::Option<IMFActivate>,
+    pcsourceactivate: *mut u32,
+) -> ::windows::core::Result<()>
+where
+    P0: ::std::convert::Into<::windows::core::InParam<'a, IMFAttributes>>,
+{
+    let lib = MF_WRAPPER.lock().unwrap();
+    if let Some(f) = lib.MFEnumDeviceSources {
+        f(
+            pattributes.into().abi() as _,
+            ::core::mem::transmute(pppsourceactivate),
+            ::core::mem::transmute(pcsourceactivate),
+        )
+        .ok()
+    } else {
+        Err(HRESULT_ERR_NO_INTERFACE.into())
+    }
+}
+
+pub unsafe fn MFCreateMediaType() -> ::windows::core::Result<IMFMediaType> {
+    let lib = MF_PLAT_WRAPPER.lock().unwrap();
+    if let Some(f) = lib.MFCreateMediaType {
+        let mut result__ = ::core::mem::MaybeUninit::zeroed();
+        f(::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFMediaType>(result__)
+    } else {
+        Err(HRESULT_ERR_NO_INTERFACE.into())
+    }
+}
+
+pub unsafe fn MFCreateAttributes(
+    ppmfattributes: *mut ::core::option::Option<IMFAttributes>,
+    cinitialsize: u32,
+) -> ::windows::core::Result<()> {
+    let lib = MF_PLAT_WRAPPER.lock().unwrap();
+    if let Some(f) = lib.MFCreateAttributes {
+        f(::core::mem::transmute(ppmfattributes), cinitialsize).ok()
+    } else {
+        Err(HRESULT_ERR_NO_INTERFACE.into())
+    }
+}
+
+pub unsafe fn MFStartup(version: u32, dwflags: u32) -> ::windows::core::Result<()> {
+    let lib = MF_PLAT_WRAPPER.lock().unwrap();
+    if let Some(f) = lib.MFStartup {
+        f(version, dwflags).ok()
+    } else {
+        Err(HRESULT_ERR_NO_INTERFACE.into())
+    }
+}
+
+pub unsafe fn MFShutdown() -> ::windows::core::Result<()> {
+    let lib = MF_PLAT_WRAPPER.lock().unwrap();
+    if let Some(f) = lib.MFShutdown {
+        f().ok()
+    } else {
+        Err(HRESULT_ERR_NO_INTERFACE.into())
+    }
+}
+
+pub unsafe fn MFCreateSample() -> ::windows::core::Result<IMFSample> {
+    let lib = MF_PLAT_WRAPPER.lock().unwrap();
+    if let Some(f) = lib.MFCreateSample {
+        let mut result__ = ::core::mem::MaybeUninit::zeroed();
+        f(::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFSample>(result__)
+    } else {
+        Err(HRESULT_ERR_NO_INTERFACE.into())
+    }
+}
+
+pub unsafe fn MFCreateSourceReaderFromMediaSource<'a, P0, P1>(
+    pmediasource: P0,
+    pattributes: P1,
+) -> ::windows::core::Result<IMFSourceReader>
+where
+    P0: ::std::convert::Into<::windows::core::InParam<'a, IMFMediaSource>>,
+    P1: ::std::convert::Into<::windows::core::InParam<'a, IMFAttributes>>,
+{
+    let lib = MF_READ_WRITE_WRAPPER.lock().unwrap();
+    if let Some(f) = lib.MFCreateSourceReaderFromMediaSource {
+        let mut result__ = ::core::mem::MaybeUninit::zeroed();
+        f(
+            pmediasource.into().abi() as _,
+            pattributes.into().abi() as _,
+            ::core::mem::transmute(result__.as_mut_ptr()),
+        )
+        .from_abi::<IMFSourceReader>(result__)
+    } else {
+        Err(HRESULT_ERR_NO_INTERFACE.into())
+    }
+}


### PR DESCRIPTION
Tested on Win10 Pro N, which has no `mf.dll`.

"View camera" still works.
