### PR TITLE
fix v4l2 camera Error: Framerate not whole number when numerator is not 1

### DIFF
--- a/nokhwa-bindings-linux/src/lib.rs
+++ b/nokhwa-bindings-linux/src/lib.rs
@@ -215,7 +215,7 @@ mod internal {
                 let fps = match device.params() {
                     Ok(params) => {
                         if params.interval.numerator != 1
-                            || params.interval.denominator % params.interval.numerator != 0
+                            && params.interval.denominator % params.interval.numerator != 0
                         {
                             return Err(NokhwaError::GetPropertyError {
                                 property: "V4L2 FrameRate".to_string(),

--- a/nokhwa-bindings-linux/src/lib.rs
+++ b/nokhwa-bindings-linux/src/lib.rs
@@ -363,7 +363,7 @@ mod internal {
                 camera_formats.append(&mut formats);
             }
 
-            let format = cam_fmt
+            let mut format = cam_fmt
                 .fulfill(&camera_formats)
                 .ok_or(NokhwaError::GetPropertyError {
                     property: "CameraFormat".to_string(),
@@ -371,31 +371,34 @@ mod internal {
                 })?;
 
             let current_format = get_device_format(&device)?;
-
-            if current_format.width() != format.width()
-                || current_format.height() != format.height()
-                || current_format.format() != format.format()
-            {
-                if let Err(why) = device.set_format(&Format::new(
-                    format.width(),
-                    format.height(),
-                    frameformat_to_fourcc(format.format()),
-                )) {
-                    return Err(NokhwaError::SetPropertyError {
-                        property: "Resolution, FrameFormat".to_string(),
-                        value: format.to_string(),
-                        error: why.to_string(),
-                    });
+            if cam_fmt.requested_format_type() == RequestedFormatType::None {
+                format = current_format;
+            } else {
+                if current_format.width() != format.width()
+                    || current_format.height() != format.height()
+                    || current_format.format() != format.format()
+                {
+                    if let Err(why) = device.set_format(&Format::new(
+                        format.width(),
+                        format.height(),
+                        frameformat_to_fourcc(format.format()),
+                    )) {
+                        return Err(NokhwaError::SetPropertyError {
+                            property: "Resolution, FrameFormat".to_string(),
+                            value: format.to_string(),
+                            error: why.to_string(),
+                        });
+                    }
                 }
-            }
 
-            if current_format.frame_rate() != format.frame_rate() {
-                if let Err(why) = device.set_params(&Parameters::with_fps(format.frame_rate())) {
-                    return Err(NokhwaError::SetPropertyError {
-                        property: "Frame rate".to_string(),
-                        value: format.frame_rate().to_string(),
-                        error: why.to_string(),
-                    });
+                if current_format.frame_rate() != format.frame_rate() {
+                    if let Err(why) = device.set_params(&Parameters::with_fps(format.frame_rate())) {
+                        return Err(NokhwaError::SetPropertyError {
+                            property: "Frame rate".to_string(),
+                            value: format.frame_rate().to_string(),
+                            error: why.to_string(),
+                        });
+                    }
                 }
             }
 


### PR DESCRIPTION
with camera parm like this:
```
v4l2-ctl --device=/dev/video0 --get-parm
Streaming Parameters Video Capture:
        Capabilities     : timeperframe
        Frames per second: 15.000 (15000/1000)
        Read buffers     : 1
```

test always fail with FrameRate error
```
nokhwactl list-properties 0 All
Nokhwa Initalized: true
device supported format: Ok("YUYV")

thread 'main' panicked at examples/capture/src/main.rs:310:14:
called `Result::unwrap()` on an `Err` value: GetPropertyError { property: "V4L2 FrameRate", error: "Framerate not whole number: 15000 / 1000" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```