### PR TITLE
fix: win, infinite loop

### DIFF
--- a/nokhwa-bindings-windows/src/lib.rs
+++ b/nokhwa-bindings-windows/src/lib.rs
@@ -51,7 +51,7 @@ pub mod wmf {
     };
     use windows::Win32::Media::DirectShow::{CameraControl_Flags_Auto, CameraControl_Flags_Manual};
     use windows::Win32::Media::MediaFoundation::{
-        IMFMediaType, MF_SOURCE_READER_CURRENT_TYPE_INDEX, MF_SOURCE_READER_FIRST_VIDEO_STREAM,
+        IMFMediaType, MF_SOURCE_READER_FIRST_VIDEO_STREAM,
     };
     use windows::{
         core::{Interface, GUID, PWSTR},
@@ -633,6 +633,7 @@ pub mod wmf {
             let mut index: u32 = 0;
 
             // https://learn.microsoft.com/en-us/windows/win32/api/mfreadwrite/nf-mfreadwrite-imfsourcereader-getnativemediatype
+            // https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Media/MediaFoundation/struct.IMFSourceReader.html#method.GetNativeMediaType
             while let Ok(media_type) = unsafe {
                 self.source_reader
                     .GetNativeMediaType(MEDIA_FOUNDATION_FIRST_VIDEO_STREAM, index)
@@ -708,10 +709,12 @@ pub mod wmf {
                 let frame_fmt = match guid_to_frameformat(fourcc) {
                     Some(fcc) => fcc,
                     None => {
-                        if index == MF_SOURCE_READER_CURRENT_TYPE_INDEX.0 as u32 {
+                        index += 1;
+                        // This condition should not be hit in normal cases.
+                        // But we still add the check to ensure we can break out of the loop.
+                        if index == 0 {
                             break;
                         }
-                        index += 1;
                         continue;
                     }
                 };
@@ -726,10 +729,12 @@ pub mod wmf {
                     }
                 }
 
-                if index == MF_SOURCE_READER_CURRENT_TYPE_INDEX.0 as u32 {
+                index += 1;
+                // This condition should not be hit in normal cases.
+                // But we still add the check to ensure we can break out of the loop.
+                if index == 0 {
                     break;
                 }
-                index += 1;
             }
             Ok(camera_format_list)
         }

--- a/nokhwa-bindings-windows/src/lib.rs
+++ b/nokhwa-bindings-windows/src/lib.rs
@@ -51,7 +51,7 @@ pub mod wmf {
     };
     use windows::Win32::Media::DirectShow::{CameraControl_Flags_Auto, CameraControl_Flags_Manual};
     use windows::Win32::Media::MediaFoundation::{
-        IMFMediaType, MF_SOURCE_READER_FIRST_VIDEO_STREAM,
+        IMFMediaType, MF_SOURCE_READER_CURRENT_TYPE_INDEX, MF_SOURCE_READER_FIRST_VIDEO_STREAM,
     };
     use windows::{
         core::{Interface, GUID, PWSTR},
@@ -632,6 +632,7 @@ pub mod wmf {
             let mut camera_format_list = vec![];
             let mut index = 0;
 
+            // https://learn.microsoft.com/en-us/windows/win32/api/mfreadwrite/nf-mfreadwrite-imfsourcereader-getnativemediatype
             while let Ok(media_type) = unsafe {
                 self.source_reader
                     .GetNativeMediaType(MEDIA_FOUNDATION_FIRST_VIDEO_STREAM, index)
@@ -706,7 +707,13 @@ pub mod wmf {
 
                 let frame_fmt = match guid_to_frameformat(fourcc) {
                     Some(fcc) => fcc,
-                    None => continue,
+                    None => {
+                        if index == MF_SOURCE_READER_CURRENT_TYPE_INDEX.0 as u32 {
+                            break;
+                        }
+                        index += 1;
+                        continue;
+                    }
                 };
 
                 for frame_rate in framerate_list {
@@ -719,6 +726,9 @@ pub mod wmf {
                     }
                 }
 
+                if index == MF_SOURCE_READER_CURRENT_TYPE_INDEX.0 as u32 {
+                    break;
+                }
                 index += 1;
             }
             Ok(camera_format_list)

--- a/nokhwa-bindings-windows/src/lib.rs
+++ b/nokhwa-bindings-windows/src/lib.rs
@@ -630,7 +630,7 @@ pub mod wmf {
 
         pub fn compatible_format_list(&mut self) -> Result<Vec<CameraFormat>, NokhwaError> {
             let mut camera_format_list = vec![];
-            let mut index = 0;
+            let mut index: u32 = 0;
 
             // https://learn.microsoft.com/en-us/windows/win32/api/mfreadwrite/nf-mfreadwrite-imfsourcereader-getnativemediatype
             while let Ok(media_type) = unsafe {


### PR DESCRIPTION

https://www.reddit.com/r/rustdesk/comments/1m77mt0/comment/n4temqe/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button

1. `index += 1;` is missed.

<img width="1329" height="386" alt="image" src="https://github.com/user-attachments/assets/454707fd-df72-4cdc-9c5c-9bfe9f8f854c" />

2. Check if `index` is equal to `0` after `index += 1`. The condition should not be reached, but we just add it for safety (break the loop).

https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Media/MediaFoundation/struct.IMFSourceReader.html#method.GetNativeMediaType

